### PR TITLE
Switch Reflections for FastClasspathScanner for DDL Discovery and Add Compression Flag to Create Tool.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -33,7 +33,7 @@
     <description>Kiji table layout updater tool</description>
     <groupId>com.opower</groupId>
     <artifactId>kiji-table-layout-updater</artifactId>
-    <version>0.1.1</version>
+    <version>0.1.2</version>
     <packaging>jar</packaging>
 
     <scm>
@@ -83,9 +83,9 @@
         </dependency>
 
         <dependency>
-            <groupId>org.reflections</groupId>
-            <artifactId>reflections</artifactId>
-            <version>0.9.9-RC1</version>
+            <groupId>io.github.lukehutch</groupId>
+            <artifactId>fast-classpath-scanner</artifactId>
+            <version>1.8.1</version>
         </dependency>
 
         <dependency>

--- a/src/test/java/com/opower/updater/TestUpdaterUpdateTool.java
+++ b/src/test/java/com/opower/updater/TestUpdaterUpdateTool.java
@@ -40,10 +40,17 @@ public class TestUpdaterUpdateTool extends UpdaterToolTest {
         Client client = Client.newInstance(getKiji().getURI());
         client.executeUpdate(loader.loadCreateTable(TABLE_NAME)
                 .getDDL()
-                .replaceAll(DDLTokenReplacer.TOKEN_DELIMITER
-                        + UpdaterCreateTool.NUM_REGIONS_TOKEN
-                        + DDLTokenReplacer.TOKEN_DELIMITER,
-                        "1"));
+                .replaceAll(
+                        DDLTokenReplacer.TOKEN_DELIMITER
+                                + UpdaterCreateTool.NUM_REGIONS_TOKEN
+                                + DDLTokenReplacer.TOKEN_DELIMITER,
+                        "1")
+                .replaceAll(
+                        DDLTokenReplacer.TOKEN_DELIMITER
+                                + UpdaterCreateTool.COMPRESSION_TOKEN
+                                + DDLTokenReplacer.TOKEN_DELIMITER,
+                        "NONE")
+        );
 
         assertEquals(BaseTool.FAILURE, runTool(updateTool(), "--table=" + tableURI));
         checkLastPrintedLineIsAnError();
@@ -59,7 +66,11 @@ public class TestUpdaterUpdateTool extends UpdaterToolTest {
                 .replaceAll(DDLTokenReplacer.TOKEN_DELIMITER
                         + UpdaterCreateTool.NUM_REGIONS_TOKEN
                         + DDLTokenReplacer.TOKEN_DELIMITER,
-                        "1");
+                        "1")
+                .replaceAll(DDLTokenReplacer.TOKEN_DELIMITER
+                        + UpdaterCreateTool.COMPRESSION_TOKEN
+                        + DDLTokenReplacer.TOKEN_DELIMITER,
+                        "NONE");
 
         Client client = Client.newInstance(getKiji().getURI());
         client.executeUpdate(createDDL);
@@ -114,6 +125,7 @@ public class TestUpdaterUpdateTool extends UpdaterToolTest {
 
         Map<String, String> tokenMap = new HashMap<String, String>(1);
         tokenMap.put(UpdaterCreateTool.NUM_REGIONS_TOKEN, "1");
+        tokenMap.put(UpdaterCreateTool.COMPRESSION_TOKEN, "GZIP");
 
         DDLTokenReplacer tokenReplacer = new DDLTokenReplacer(tokenMap);
 

--- a/src/test/resources/kiji/schema/test/000-test.ddl
+++ b/src/test/resources/kiji/schema/test/000-test.ddl
@@ -11,6 +11,7 @@ WITH LOCALITY GROUP default WITH DESCRIPTION 'Main locality group.' (
   MAXVERSIONS = INFINITY,
   TTL = FOREVER,
   INMEMORY = false,
+  COMPRESSED WITH %%%compression%%%,
   FAMILY test WITH DESCRIPTION 'Test record.' (
     stuff WITH SCHEMA ID 0
   )


### PR DESCRIPTION
@coderunner : Since `Reflections` was giving up annoying Exceptions at Runtime (at least on `OS X`), I tried `FastClasspathScanner`.
I also added a `Compression` flag to the `create` tool to set compression based on a command-line argument (especially useful since local environments usually don't have `snappy` but `snappy` is a preferred codec for prod). 